### PR TITLE
#11 vault 연결 설정 및 Hikari CP datasource 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+	implementation 'org.springframework.vault:spring-vault-core:3.0.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
@@ -46,6 +48,7 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/cherish/backend/config/db/DataSourceConfig.java
+++ b/src/main/java/cherish/backend/config/db/DataSourceConfig.java
@@ -1,0 +1,32 @@
+package cherish.backend.config.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    public HikariConfig hikariConfig(SimpleHikariConfig simpleHikariConfig) {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setUsername(simpleHikariConfig.getUsername());
+        hikariConfig.setPassword(simpleHikariConfig.getPassword());
+        hikariConfig.setDriverClassName(simpleHikariConfig.getDriverClassName());
+        hikariConfig.setJdbcUrl(simpleHikariConfig.getJdbcUrl());
+        hikariConfig.setSchema(simpleHikariConfig.getSchema());
+        return hikariConfig;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(HikariConfig hikariConfig) {
+        return new HikariDataSource(hikariConfig);
+    }
+}

--- a/src/main/java/cherish/backend/config/db/SimpleHikariConfig.java
+++ b/src/main/java/cherish/backend/config/db/SimpleHikariConfig.java
@@ -1,0 +1,12 @@
+package cherish.backend.config.db;
+
+import lombok.Data;
+
+@Data
+public class SimpleHikariConfig {
+    private String username;
+    private String password;
+    private String jdbcUrl;
+    private String driverClassName;
+    private String schema;
+}

--- a/src/main/java/cherish/backend/config/vault/VaultConfig.java
+++ b/src/main/java/cherish/backend/config/vault/VaultConfig.java
@@ -1,0 +1,51 @@
+package cherish.backend.config.vault;
+
+import cherish.backend.config.db.SimpleHikariConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.vault.authentication.AppRoleAuthentication;
+import org.springframework.vault.authentication.AppRoleAuthenticationOptions;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.config.AbstractVaultConfiguration;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Slf4j
+@EnableConfigurationProperties(VaultProperties.class)
+@Configuration
+public class VaultConfig extends AbstractVaultConfiguration {
+    private final VaultProperties vaultProperties;
+
+    @Override
+    public VaultEndpoint vaultEndpoint() {
+        try {
+            return VaultEndpoint.from(new URI(String.format("%s://%s:%s", vaultProperties.getSchema(), vaultProperties.getHost(), vaultProperties.getPort())));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ClientAuthentication clientAuthentication() {
+        AppRoleAuthenticationOptions appRoleAuthenticationOptions = null;
+        if (vaultProperties != null) {
+            appRoleAuthenticationOptions = AppRoleAuthenticationOptions.builder()
+                .roleId(AppRoleAuthenticationOptions.RoleId.provided(vaultProperties.getRoleId()))
+                .secretId(AppRoleAuthenticationOptions.SecretId.provided(vaultProperties.getSecretId()))
+                .build();
+        }
+        return appRoleAuthenticationOptions != null ? new AppRoleAuthentication(appRoleAuthenticationOptions, restOperations()) : null;
+    }
+
+    @Bean
+    public SimpleHikariConfig simpleHikariConfig() {
+        return Objects.requireNonNull(vaultTemplate().read(vaultProperties.getVaultPath(), SimpleHikariConfig.class)).getData();
+    }
+}

--- a/src/main/java/cherish/backend/config/vault/VaultProperties.java
+++ b/src/main/java/cherish/backend/config/vault/VaultProperties.java
@@ -1,0 +1,17 @@
+package cherish.backend.config.vault;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(VaultProperties.PREFIX)
+@Data
+public class VaultProperties {
+    public static final String PREFIX = "vault.props";
+
+    private String host;
+    private int port;
+    private String schema;
+    private String roleId;
+    private String secretId;
+    private String vaultPath;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,17 @@
 spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/cherish
-    username: postgres
-    password: 12345
-    show-sql: true
-  jpa:
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        default_batch_fetch_size: 100
-        format_sql: create
-        dialect: org.hibernate.dialect.PostgreSQLDialect
   profiles:
     include: smtp
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+vault.props:
+  schema: http
+  host: ec2-54-180-219-125.ap-northeast-2.compute.amazonaws.com
+  port: 8200
+  roleId: c34df00a-8f11-10ba-a4ff-adc4242b9b65
+  secretId: 9c1ae635-6ea1-7680-4290-688b54855893
+  vaultPath: kv/datasource
 
 logging:
   level:
@@ -37,7 +35,7 @@ mail:
     port: 465
 
 AdminMail:
-  id: ${MAIL_USERNAME}
-  password: ${MAIL_PASSWORD}
+  id: temp
+  password: temp
 
 


### PR DESCRIPTION
- build.gradle에 spring vault core, configuration-processor 추가
- application.yml에 vault 접속 정보 추가
- [SimpleHikariConfig.java] vault에 저장한 값들 받아올 수 있는 POJO
- 위 POJO로 Hikari CP datasource 빈 생성

정말 힘들었습니다,, ㅜㅜ

리뷰 approve 하시기 전에 로컬에 이 브랜치 풀받아서 꼭 실행해보세요