### PR TITLE
Bug/#63 validation + #62 LocalDate 출력 통일화

### DIFF
--- a/src/main/java/cherish/backend/BackendApplication.java
+++ b/src/main/java/cherish/backend/BackendApplication.java
@@ -2,9 +2,7 @@ package cherish.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/cherish/backend/auth/security/SecurityConfig.java
+++ b/src/main/java/cherish/backend/auth/security/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
+        config.addAllowedOrigin(CommonConstants.LOCALHOST);
         config.addAllowedOrigin(CommonConstants.CLIENT_ORIGIN); // 프론트 IPv4 주소
         config.addAllowedMethod(""); // 모든 메소드 허용.
         config.addAllowedHeader("");

--- a/src/main/java/cherish/backend/auth/security/SecurityConfig.java
+++ b/src/main/java/cherish/backend/auth/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     // 현재 화이트 리스트 모두 열어 놓음
     private static final String[] PUBLIC_WHITELIST = {
-            "/public/**"
+            "/public/**", "/test/**"
     };
 
     // 비밀번호 변환 알고리즘

--- a/src/main/java/cherish/backend/common/aop/GlobalExceptionHandler.java
+++ b/src/main/java/cherish/backend/common/aop/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.util.ObjectUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -66,6 +67,13 @@ public class GlobalExceptionHandler {
     public ErrorResponseDto handleIllegalStateException(IllegalStateException e){
         return createError(e);
     }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadCredentialsException.class)
+    public ErrorResponseDto handleCredential(BadCredentialsException e){
+        return createError("로그인에 실패하였습니다.");
+    }
+
 
     // 공통 예외 처리
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/cherish/backend/common/config/DateFormatConfig.java
+++ b/src/main/java/cherish/backend/common/config/DateFormatConfig.java
@@ -1,0 +1,23 @@
+package cherish.backend.common.config;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class DateFormatConfig {
+
+    private static final String dateFormat = "yyyy년 MM월 dd일";
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer(){
+        return jacksonObjectMapperBuilder -> {
+            jacksonObjectMapperBuilder.timeZone(TimeZone.getTimeZone("Asia/Seoul"));
+            jacksonObjectMapperBuilder.serializers(new LocalDateSerializer(DateTimeFormatter.ofPattern(dateFormat)));
+        };
+    }
+}

--- a/src/main/java/cherish/backend/common/config/JpaAuditingConfig.java
+++ b/src/main/java/cherish/backend/common/config/JpaAuditingConfig.java
@@ -1,0 +1,15 @@
+package cherish.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ *  Mock mvc시 매번
+ *  @MockBean(JpaMetamodelMappingContext.class)
+ *  를 적어줘야해서 설정 파일로 뺐다.
+ *  혹시 @DataJpaTest를 쓰면 해당 파일을 Import 해야한다.
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/cherish/backend/member/controller/PublicMemberController.java
+++ b/src/main/java/cherish/backend/member/controller/PublicMemberController.java
@@ -27,7 +27,7 @@ public class PublicMemberController {
     //회원 회원가입
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/register")
-    public String register(@RequestBody @Valid MemberFormDto memberFormDto){
+    public Long register(@RequestBody @Valid MemberFormDto memberFormDto){
         return memberService.join(memberFormDto);
     }
 

--- a/src/main/java/cherish/backend/member/controller/PublicMemberController.java
+++ b/src/main/java/cherish/backend/member/controller/PublicMemberController.java
@@ -36,7 +36,7 @@ public class PublicMemberController {
     public TokenInfo login(@RequestBody @Valid MemberLoginRequestDto memberLoginRequestDto) {
         TokenInfo token = memberService.login(memberLoginRequestDto.getEmail(),
                 memberLoginRequestDto.getPassword(),
-                memberLoginRequestDto.getIsPersist());
+                memberLoginRequestDto.isPersist());
         log.info("member_login = {}", memberLoginRequestDto.getEmail());
         return token;
     }

--- a/src/main/java/cherish/backend/member/dto/MemberFormDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberFormDto.java
@@ -1,6 +1,7 @@
 package cherish.backend.member.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -17,7 +18,7 @@ public class MemberFormDto {
     private String email; // 이메일
     @NotEmpty
     private String password; // 패스워드
-    @NotEmpty
+    @NotNull
     private boolean infoCheck; // 광고성 동의
     // 추가 정보
     private String gender; // 성별

--- a/src/main/java/cherish/backend/member/dto/MemberFormDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberFormDto.java
@@ -3,26 +3,27 @@ package cherish.backend.member.dto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
 
-@AllArgsConstructor
+@Builder
 @Data
 public class MemberFormDto {
     @NotEmpty
-    private String name; // 이름
+    private final String name; // 이름
     @NotEmpty
-    private String nickName; // 닉네임
+    private final String nickName; // 닉네임
     @NotEmpty
-    private String email; // 이메일
+    private final String email; // 이메일
     @NotEmpty
-    private String password; // 패스워드
+    private final String password; // 패스워드
     @NotNull
-    private boolean infoCheck; // 광고성 동의
+    private final boolean infoCheck; // 광고성 동의
     // 추가 정보
-    private String gender; // 성별
-    private LocalDate birth; // 생일
-    private String job;
+    private final String gender; // 성별
+    private final LocalDate birth; // 생일
+    private final String job;
 
 }

--- a/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
@@ -2,6 +2,7 @@ package cherish.backend.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
@@ -11,6 +12,6 @@ public class MemberLoginRequestDto {
     private String email;
     @NotEmpty
     private String password;
-    @NotEmpty
-    private Boolean isPersist;
+    @NotNull
+    private boolean isPersist;
 }

--- a/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
@@ -3,15 +3,16 @@ package cherish.backend.member.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 public class MemberLoginRequestDto {
     @NotEmpty
     @Email
-    private String email;
+    private final String email;
     @NotEmpty
-    private String password;
+    private final String password;
     @NotNull
-    private boolean isPersist;
+    private final boolean isPersist;
 }

--- a/src/main/java/cherish/backend/member/service/MemberService.java
+++ b/src/main/java/cherish/backend/member/service/MemberService.java
@@ -51,14 +51,14 @@ public class MemberService {
     }
 
     @Transactional
-    public String join(MemberFormDto memberFormDto) {
+    public Long join(MemberFormDto memberFormDto) {
         boolean isAlready = memberRepository.existsByEmail(memberFormDto.getEmail());
         if (isAlready){
             throw new IllegalStateException(Constants.EMAIL_ALREADY);
         }
         else {
             Member savedMember = memberRepository.save(Member.createMember(memberFormDto, passwordEncoder));
-            return savedMember.getEmail();
+            return savedMember.getId();
         }
     }
 

--- a/src/main/java/cherish/backend/test/TestRestController.java
+++ b/src/main/java/cherish/backend/test/TestRestController.java
@@ -4,18 +4,16 @@ import cherish.backend.common.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Profile("local")
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("test")
+@RequestMapping("/test")
 public class TestRestController {
 
     private final RedisService redisService;
@@ -41,4 +39,8 @@ public class TestRestController {
         return "ok";
     }
 
+    @GetMapping("/date")
+    public LocalDate testDate(@RequestParam("date") LocalDate date){
+        return date;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
       port: 6379
       repositories:
         enabled: false
+    jpa:
+      repositories:
+        bootstrap-mode: deferred
 
 decorator:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+      repositories:
+        enabled: false
+
 decorator:
   datasource:
     p6spy:

--- a/src/test/java/cherish/backend/item/controller/ItemLikeControllerTest.java
+++ b/src/test/java/cherish/backend/item/controller/ItemLikeControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@MockBean(JpaMetamodelMappingContext.class)
+
 @WebMvcTest(ItemLikeController.class)
 class ItemLikeControllerTest {
 

--- a/src/test/java/cherish/backend/item/controller/ItemLikeControllerTest.java
+++ b/src/test/java/cherish/backend/item/controller/ItemLikeControllerTest.java
@@ -1,0 +1,50 @@
+package cherish.backend.item.controller;
+
+import cherish.backend.item.dto.ItemLikeRequest;
+import cherish.backend.item.service.ItemLikeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(ItemLikeController.class)
+class ItemLikeControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    ItemLikeService service;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(username = "test@naver.com")
+    public void 아이템_좋아요() throws Exception {
+        //given
+        given(service.likeItem(any(),any())).willReturn(3L);
+        String content = objectMapper.writeValueAsString(new ItemLikeRequest("test@naver.com", 3L));
+        //when
+        mvc.perform(post("/item/like")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON).with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("3"));
+    }
+
+
+}

--- a/src/test/java/cherish/backend/member/MemberTest.java
+++ b/src/test/java/cherish/backend/member/MemberTest.java
@@ -1,7 +1,6 @@
 package cherish.backend.member;
 
 import cherish.backend.member.dto.MemberFormDto;
-import cherish.backend.member.model.enums.Gender;
 import cherish.backend.member.model.Member;
 import cherish.backend.member.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
@@ -10,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 
 @SpringBootTest
@@ -36,7 +33,13 @@ class MemberTest {
     }
 
     private static MemberFormDto getMemberFormDto() {
-        MemberFormDto memberFormDto = new MemberFormDto("지수빈", "공주", "test@naver.com", "1234", true, "NONE", LocalDate.now(), "공주");
+        MemberFormDto memberFormDto = MemberFormDto.builder()
+                .name("testUser")
+                .email("test@naver.com")
+                .password("123456")
+                .nickName("test-man")
+                .infoCheck(true)
+                .build();
         return memberFormDto;
     }
 

--- a/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
+++ b/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
@@ -1,7 +1,10 @@
 package cherish.backend.member.controller;
 
+import cherish.backend.auth.jwt.TokenInfo;
+import cherish.backend.member.dto.MemberLoginRequestDto;
 import cherish.backend.member.dto.email.EmailCodeValidationRequest;
 import cherish.backend.member.dto.email.EmailRequest;
+import cherish.backend.member.model.Member;
 import cherish.backend.member.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -15,14 +18,14 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Slf4j
 @MockBean(JpaMetamodelMappingContext.class)
-@WebMvcTest(MemberController.class)
+@WebMvcTest({MemberController.class, PublicMemberController.class})
 class MemberControllerTest {
 
     @Autowired
@@ -64,8 +67,31 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON).with(csrf()))
                 .andExpect(status().isOk());
-
-
     }
+
+    @Test
+    @WithMockUser
+    void 로그인_테스트() throws Exception {
+        //given
+        Member member = Member.builder().id(1L).name("test").email("test@naver.com").password("12345").build();
+        given(memberService.login(member.getEmail(), member.getPassword(),false )).willReturn(
+                TokenInfo.builder()
+                .grantType("Bearer").refreshToken("abc").accessToken("cde").build()
+        );
+        //when
+        //then
+        String content = objectMapper.writeValueAsString(new MemberLoginRequestDto("test@naver.com", "12345", false));
+        mvc.perform(post("/public/member/login")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.refreshToken").value("abc"))
+                .andExpect(jsonPath("$.accessToken").value("cde"));
+    }
+
 
 }

--- a/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
+++ b/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,7 +23,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Slf4j
-@MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest({MemberController.class, PublicMemberController.class})
 class MemberControllerTest {
 

--- a/src/test/java/cherish/backend/member/service/MemberServiceUnitTest.java
+++ b/src/test/java/cherish/backend/member/service/MemberServiceUnitTest.java
@@ -1,0 +1,53 @@
+package cherish.backend.member.service;
+
+import cherish.backend.member.dto.MemberFormDto;
+import cherish.backend.member.model.Member;
+import cherish.backend.member.model.enums.Gender;
+import cherish.backend.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceUnitTest {
+
+    @Mock
+    private MemberRepository repository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    void 회원_가입(){
+        //given
+        given(repository.save(any())).willReturn(Member.builder().id(1L).name("testUser").build());
+        MemberFormDto memberFormDto = createTestMember();
+        //when
+        Long joinId = memberService.join(memberFormDto);
+        // then
+        Assertions.assertThat(joinId).isEqualTo(1L);
+    }
+
+    private static MemberFormDto createTestMember() {
+        return MemberFormDto.builder()
+                .name("testUser")
+                .email("test@naver.com")
+                .password("123456")
+                .nickName("test-man")
+                .infoCheck(true)
+                .gender(String.valueOf(Gender.MALE))
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 같이 보면 좋을듯하여 작성합니다.

### validation
1. `@NotEmpty` 는 String과 collection 타입에만 적용이 된다.
2. `@NotNull` 은 모든 데이터 타입에 null 허용 하지 않는다.
3. `@NotBlank` null과 "" 허용하지않는다.

### redis repository
 스프링이 실행될 때 뜨는 불편한 로그를 삭제하도록 한다.
이유: JPA와 Redis Repository가 서로를 인식해서 나오는 로그
<img width="910" alt="스크린샷 2023-04-02 오후 5 31 44" src="https://user-images.githubusercontent.com/81786969/229341647-0ce03c8e-da4a-4ed6-80ab-eca09e184db9.png">

방법은 
1. 스캔대상을 정해주거나( 디렉토리 구조때문에 번거로움)
2. redisTemplate 만 사용한다면 yml 수정 

### BootstrapMode for JPA Repositories
<img width="898" alt="스크린샷 2023-04-02 오후 5 33 06" src="https://user-images.githubusercontent.com/81786969/229341730-dc8b4305-2fb3-4936-be9e-d9088a05d8f4.png">
 고로 deferred 설정

[공식문서](https://www.baeldung.com/jpa-bootstrap-mode)

### LocalDate 출력 통일화
<img width="848" alt="스크린샷 2023-04-02 오후 5 44 04" src="https://user-images.githubusercontent.com/81786969/229342285-429c590b-e3bb-4c43-84ba-bcae9eb4038f.png">
