### PR TITLE
Bug/#65 클라이언트 JSON 바인딩 에러 해결을 위한 @NoArgsConstructor 추가

### DIFF
--- a/src/main/java/cherish/backend/common/aop/GlobalExceptionHandler.java
+++ b/src/main/java/cherish/backend/common/aop/GlobalExceptionHandler.java
@@ -18,23 +18,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final String NO_ERROR_MESSAGE = "No error message from server.";
-    private static final ErrorResponseDto DEFAULT_ERROR_RESPONSE = new ErrorResponseDto(NO_ERROR_MESSAGE);
+    private static final String DEFAULT_ERROR_MSG = "알 수 없는 에러가 발생했습니다. 운영자에게 문의 바랍니다.";
+    private static final ErrorResponseDto DEFAULT_ERROR_RESPONSE = new ErrorResponseDto(DEFAULT_ERROR_MSG);
 
     private ErrorResponseDto createError(Exception e) {
         log.error(e.getMessage(), e);
-        if (ObjectUtils.isEmpty(e.getMessage())) {
-            return DEFAULT_ERROR_RESPONSE;
-        }
-        return new ErrorResponseDto(e.getMessage());
+        return DEFAULT_ERROR_RESPONSE;
     }
 
-    private ErrorResponseDto createError(String s) {
-        if (ObjectUtils.isEmpty(s)) {
-            return DEFAULT_ERROR_RESPONSE;
-        }
-        log.error(s);
-        return new ErrorResponseDto(s);
+    private ErrorResponseDto createError(Exception e, String message) {
+        log.error(e.getMessage(), e);
+        return new ErrorResponseDto(message);
     }
 
     // 자바 빈 검증 예외 처리
@@ -54,12 +48,12 @@ public class GlobalExceptionHandler {
             builder.append("]");
         }
 
-        return createError(builder.toString());
+        return createError(e, builder.toString());
     }
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({TypeMismatchException.class, HttpMessageNotReadableException.class})
     public ErrorResponseDto handleTypeException(Exception e){
-        return createError("타입 오류입니다.");
+        return createError(e, "타입 오류입니다.");
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -71,7 +65,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BadCredentialsException.class)
     public ErrorResponseDto handleCredential(BadCredentialsException e){
-        return createError("로그인에 실패하였습니다.");
+        return createError(e, "로그인에 실패하였습니다.");
     }
 
 

--- a/src/main/java/cherish/backend/item/controller/ItemLikeController.java
+++ b/src/main/java/cherish/backend/item/controller/ItemLikeController.java
@@ -20,8 +20,7 @@ public class ItemLikeController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/like")
     public Long itemLike(@RequestBody ItemLikeRequest request){
-        Long itemLikeId = itemLikeService.likeItem(request.getEmail(), request.getItemId());
-        return itemLikeId;
+        return itemLikeService.likeItem(request.getEmail(), request.getItemId());
     }
 
     @DeleteMapping("/like")

--- a/src/main/java/cherish/backend/item/dto/ItemLikeRequest.java
+++ b/src/main/java/cherish/backend/item/dto/ItemLikeRequest.java
@@ -1,9 +1,15 @@
 package cherish.backend.item.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ItemLikeRequest {
-    private final String email;
-    private final Long itemId;
+    private String email;
+    private Long itemId;
 }

--- a/src/main/java/cherish/backend/member/controller/MemberController.java
+++ b/src/main/java/cherish/backend/member/controller/MemberController.java
@@ -1,13 +1,12 @@
 package cherish.backend.member.controller;
 
 import cherish.backend.auth.security.SecurityUser;
-import cherish.backend.member.dto.*;
+import cherish.backend.member.dto.ChangeInfoRequest;
+import cherish.backend.member.dto.MemberInfoResponse;
 import cherish.backend.member.service.MemberService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,16 +17,14 @@ public class MemberController {
     private final MemberService memberService;
     // 회원 삭제
     @DeleteMapping("/delete")
-    public ResponseEntity delete(@RequestParam("email") @Email String email, @AuthenticationPrincipal SecurityUser securityUser){
+    public void delete(@RequestParam("email") @Email String email, @AuthenticationPrincipal SecurityUser securityUser){
         memberService.delete(email,securityUser.getMember().getEmail());
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     // 회원 수정
     @PatchMapping("/change-info")
-    public ResponseEntity changeInfo(@RequestBody @Valid ChangeInfoRequest request){
-        Long memberId = memberService.changeInfo(request.getNickName(), request.getJobName(), request.getEmail());
-        return ResponseEntity.status(HttpStatus.OK).body(memberId);
+    public Long changeInfo(@RequestBody @Valid ChangeInfoRequest request){
+        return memberService.changeInfo(request.getNickName(), request.getJobName(), request.getEmail());
     }
     // 유틸 테스트
     // 객체로 받아오는 것

--- a/src/main/java/cherish/backend/member/controller/PublicMemberController.java
+++ b/src/main/java/cherish/backend/member/controller/PublicMemberController.java
@@ -13,7 +13,6 @@ import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -51,20 +50,17 @@ public class PublicMemberController {
     // 기존비밀번호 확인이 체크가 되어있거나
     // 혹은 현재 로그인한 사용자가 바꾸길 원하는 이메일과 같은 경우
     @PostMapping("/change-password")
-    public ResponseEntity changePwd(@RequestBody @Valid ChangePwdRequest request){
+    public void changePwd(@RequestBody @Valid ChangePwdRequest request){
         memberService.changePwd(request.getEmail(),request.getPassword());
-        return new ResponseEntity(HttpStatus.OK);
     }
     // 이메일 코드 발송
     @PostMapping("/code-send")
-    public ResponseEntity sendEmailCode(@RequestBody @Valid EmailRequest emailRequest){
-        String code = memberService.sendEmailCode(emailRequest.getEmail());
-        return ResponseEntity.status(HttpStatus.OK).body(code);
+    public String sendEmailCode(@RequestBody @Valid EmailRequest emailRequest){
+        return memberService.sendEmailCode(emailRequest.getEmail());
     }
     // 이메일 코드 검증
     @PostMapping("/code-valid")
-    public ResponseEntity validEmailCode(@RequestBody @Valid EmailCodeValidationRequest request){
+    public void validEmailCode(@RequestBody @Valid EmailCodeValidationRequest request){
         memberService.validEmailCode(request.getEmail(), request.getCode());
-        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/src/main/java/cherish/backend/member/dto/ChangeInfoRequest.java
+++ b/src/main/java/cherish/backend/member/dto/ChangeInfoRequest.java
@@ -2,9 +2,15 @@ package cherish.backend.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChangeInfoRequest {
     @Email
     private String email;

--- a/src/main/java/cherish/backend/member/dto/ChangePwdRequest.java
+++ b/src/main/java/cherish/backend/member/dto/ChangePwdRequest.java
@@ -2,13 +2,19 @@ package cherish.backend.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChangePwdRequest {
     @Email
-    private final String email;
+    private String email;
 
     @NotEmpty
-    private final String password;
+    private String password;
 }

--- a/src/main/java/cherish/backend/member/dto/MemberFormDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberFormDto.java
@@ -5,25 +5,28 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberFormDto {
     @NotEmpty
-    private final String name; // 이름
+    private String name; // 이름
     @NotEmpty
-    private final String nickName; // 닉네임
+    private String nickName; // 닉네임
     @NotEmpty
-    private final String email; // 이메일
+    private String email; // 이메일
     @NotEmpty
-    private final String password; // 패스워드
+    private String password; // 패스워드
     @NotNull
-    private final boolean infoCheck; // 광고성 동의
+    private boolean infoCheck; // 광고성 동의
     // 추가 정보
-    private final String gender; // 성별
-    private final LocalDate birth; // 생일
-    private final String job;
+    private String gender; // 성별
+    private LocalDate birth; // 생일
+    private String job;
 
 }

--- a/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
+++ b/src/main/java/cherish/backend/member/dto/MemberLoginRequestDto.java
@@ -4,15 +4,20 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberLoginRequestDto {
     @NotEmpty
     @Email
-    private final String email;
+    private String email;
     @NotEmpty
-    private final String password;
+    private String password;
     @NotNull
-    private final boolean isPersist;
+    private boolean persist;
 }

--- a/src/main/java/cherish/backend/member/dto/email/EmailCodeValidationRequest.java
+++ b/src/main/java/cherish/backend/member/dto/email/EmailCodeValidationRequest.java
@@ -1,22 +1,20 @@
 package cherish.backend.member.dto.email;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
-@Getter
+@Builder
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class EmailCodeValidationRequest {
-
     @Email
     private String email;
 
     @Length(min = 6, max = 6)
     private String code;
-
 }

--- a/src/main/java/cherish/backend/member/dto/email/EmailRequest.java
+++ b/src/main/java/cherish/backend/member/dto/email/EmailRequest.java
@@ -1,17 +1,16 @@
 package cherish.backend.member.dto.email;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
+@Builder
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class EmailRequest {
-
     @Email
     private String email;
 }


### PR DESCRIPTION
클라이언트에서 JSON으로 body를 담아 보낼경우 

`@RequestBody`가 제대로 바인딩되지 않는 에러를 해결하기 위해

`@NoArgsConstructor`를 추가했습니다.

추가로 내부 익셉션 에러메세지가 클라이언트로 그대로 노출되는것을 방지하기 위해

`GlobalExceptionHandler` 부분 로직을 변경했습니다.