### PR TITLE
Refactor/83 add email verification

### DIFF
--- a/src/main/java/cherish/backend/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/cherish/backend/auth/jwt/JwtTokenProvider.java
@@ -43,7 +43,7 @@ public class JwtTokenProvider {
         // Refresh Token 생성
         String refreshToken = generateRefreshToken(authentication, now);
 
-        redisService.setRedisKeyValue(refreshToken, authentication.getName(), jwtConfig.getRefreshTokenExpireMillis() / 1000);
+        redisService.setRefreshToken(authentication.getName(), refreshToken, jwtConfig.getRefreshTokenExpireMillis() / 1000);
 
         return TokenInfo.builder()
                 .grantType("Bearer")

--- a/src/main/java/cherish/backend/common/exception/RedisKeyNotFoundException.java
+++ b/src/main/java/cherish/backend/common/exception/RedisKeyNotFoundException.java
@@ -1,4 +1,0 @@
-package cherish.backend.common.exception;
-
-public class RedisKeyNotFoundException extends IllegalStateException{
-}

--- a/src/main/java/cherish/backend/common/service/RedisService.java
+++ b/src/main/java/cherish/backend/common/service/RedisService.java
@@ -1,6 +1,5 @@
 package cherish.backend.common.service;
 
-import cherish.backend.common.exception.RedisKeyNotFoundException;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +14,10 @@ import java.time.Duration;
 @RequiredArgsConstructor
 @Service
 public class RedisService {
+    private static final String REFRESH_TOKEN_PREFIX = "_rtk_";
+    private static final String EMAIL_CODE_PREFIX = "_code_";
+    private static final String EMAIL_VERIFIED_PREFIX = "_vrf_";
+    private static final String DAILY_COUNT_PREFIX = "_cnt_";
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
@@ -23,16 +26,10 @@ public class RedisService {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    /**
-     * Redis에서 가져온 JSON string을 객체로 변환해주는 util method.
-     * @param key Redis key
-     * @param type 변환할 클래스
-     * @return {@code T type} 클래스로 변환된 Redis value
-     */
     public <T> T getValue(String key, Class<T> type) {
         if (!hasKey(key)) {
             log.error("키 {}는 존재하지 않습니다", key);
-            throw new RedisKeyNotFoundException();
+            throw new RuntimeException();
         }
 
         String jsonValue = redisTemplate.opsForValue().get(key);
@@ -47,8 +44,8 @@ public class RedisService {
     /**
      * Redis에 키와 값 세팅
      *
-     * @param key Redis key
-     * @param value Redis value object
+     * @param key    Redis key
+     * @param value  Redis value object
      * @param second 지속시간 (초)
      */
     public void setRedisKeyValue(String key, Object value, long second) {
@@ -61,5 +58,62 @@ public class RedisService {
             log.error(e.getMessage(), e);
             throw new IllegalStateException();
         }
+    }
+
+    public boolean hasRefreshTokenKey(String email) {
+        return hasKey(REFRESH_TOKEN_PREFIX + email);
+    }
+
+    public boolean hasEmailCodeKey(String email) {
+        return hasKey(EMAIL_CODE_PREFIX + email);
+    }
+
+    public boolean hasVerifiedKey(String email) {
+        return hasKey(EMAIL_VERIFIED_PREFIX + email);
+    }
+
+    public boolean hasCountKey(String email) {
+        return hasKey(DAILY_COUNT_PREFIX + email);
+    }
+
+    private void set(String key, String value, long time) {
+        redisTemplate.opsForValue().set(key, value, Duration.ofSeconds(time));
+        log.info("set redis value for {} sec\n{} : {}", time, key, value);
+    }
+
+    public void setRefreshToken(String email, String value, long time) {
+        this.set(REFRESH_TOKEN_PREFIX + email, value, time);
+    }
+
+    public void setEmailCode(String email, String value, long time) {
+        this.set(EMAIL_CODE_PREFIX + email, value, time);
+    }
+
+    public void setEmailVerified(String email, boolean value, long time) {
+        this.set(EMAIL_VERIFIED_PREFIX + email, value ? "y" : "n", time);
+    }
+
+    public void setDailyCount(String email, int value, long time) {
+        this.set(REFRESH_TOKEN_PREFIX + email, String.valueOf(value), time);
+    }
+
+    private String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public String getRefreshToken(String email) {
+        return get(REFRESH_TOKEN_PREFIX + email);
+    }
+
+    public String getEmailCode(String email) {
+        return get(EMAIL_CODE_PREFIX + email);
+    }
+
+    public boolean isEmailVerified(String email) {
+        return get(EMAIL_VERIFIED_PREFIX + email).equals("y");
+    }
+
+    public int getEmailCount(String email) {
+        return Integer.parseInt(get(DAILY_COUNT_PREFIX + email));
     }
 }

--- a/src/main/java/cherish/backend/common/service/RedisService.java
+++ b/src/main/java/cherish/backend/common/service/RedisService.java
@@ -61,7 +61,7 @@ public class RedisService {
     public void setDailyCount(String email, int value) {
         LocalDateTime date = LocalDate.now().plusDays(1).atStartOfDay();
         long secondsLeftToday = ChronoUnit.SECONDS.between(LocalDateTime.now(), date);
-        this.set(REFRESH_TOKEN_PREFIX + email, String.valueOf(value), secondsLeftToday);
+        this.set(DAILY_COUNT_PREFIX + email, String.valueOf(value), secondsLeftToday);
     }
 
     private String get(String key) {

--- a/src/main/java/cherish/backend/common/service/RedisService.java
+++ b/src/main/java/cherish/backend/common/service/RedisService.java
@@ -81,7 +81,16 @@ public class RedisService {
     }
 
     public int getEmailCount(String email) {
-        return Integer.parseInt(get(DAILY_COUNT_PREFIX + email));
+        try {
+            return Integer.parseInt(get(DAILY_COUNT_PREFIX + email));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    public void incrementEmailCount(String email) {
+        int old = hasCountKey(email) ? getEmailCount(email) : 0;
+        setDailyCount(email, old + 1);
     }
 
     private void deleteKey(String key) {

--- a/src/main/java/cherish/backend/common/service/TokenRefreshService.java
+++ b/src/main/java/cherish/backend/common/service/TokenRefreshService.java
@@ -28,23 +28,23 @@ public class TokenRefreshService {
     private final Key key;
 
     public TokenInfo refreshToken(String refreshToken) {
-        // redis에 토큰이 없으면 만료 처리
-        if (!redisService.hasKey(refreshToken)) {
-            throw new JwtException(REFRESH_TOKEN_EXPIRED);
-        }
         // 토큰 payload에서 email 꺼냄
         String emailFromToken = getEmailFromToken(refreshToken);
-        // redis에서 토큰으로 email 꺼냄
-        String emailFromRedis = redisService.getValue(refreshToken, String.class);
+        // redis에 토큰이 없으면 만료 처리
+        if (!redisService.hasRefreshTokenKey(emailFromToken)) {
+            throw new JwtException(REFRESH_TOKEN_EXPIRED);
+        }
+        // redis에서 email로 토큰 꺼냄
+        String tokenFromRedis = redisService.getRefreshToken(emailFromToken);
 
-        if (!emailFromToken.equals(emailFromRedis)) {
+        if (!tokenFromRedis.equals(refreshToken)) {
             throw new JwtException(INVALID_REFRESH_TOKEN);
         }
 
         UserDetails userDetails = customUserDetailService.loadUserByUsername(emailFromToken);
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-        // 기존 refresh token redis에서 1초후 만료시킴
-        redisService.setRedisKeyValue(refreshToken, null, 1);
+        // 기존 refresh token redis에서 삭제
+        redisService.deleteRefreshTokenKey(emailFromToken);
 
         return jwtTokenProvider.generateToken(authentication);
     }

--- a/src/main/java/cherish/backend/member/constant/Constants.java
+++ b/src/main/java/cherish/backend/member/constant/Constants.java
@@ -5,5 +5,10 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class Constants {
     public static final String MEMBER_NOT_FOUND = "해당 유저가 없습니다.";
-    public static final String EMAIL_ALREADY = "해당 이메일이 이미 존재합니다.";
+    public static final String EMAIL_ALREADY = "해당 이메일로 이미 가입한 이력이 있습니다.";
+    public static final String TIME_LIMIT = "5분 내에 이메일을 재전송 할 수 없습니다.";
+    public static final String DAILY_COUNT_EXCEEDED = "하루 인증 횟수를 초과했습니다.";
+    public static final String EMAIL_CODE_NOT_FOUND = "이메일 인증 코드를 발송한 내역이 없습니다.";
+    public static final String EMAIL_VERIFICATION_EXPIRED = "이메일 인증 정보가 없거나 만료되었습니다. 이메일 인증을 다시 해주세요.";
+    public static final String EMAIL_CODE_NOT_EQUAL = "입력한 입력코드가 다릅니다.";
 }

--- a/src/main/java/cherish/backend/member/controller/PublicMemberController.java
+++ b/src/main/java/cherish/backend/member/controller/PublicMemberController.java
@@ -37,24 +37,23 @@ public class PublicMemberController {
         log.info("member_login = {}", memberLoginRequestDto.getEmail());
         return token;
     }
-
-    // 비밀번호 찾기 (해당 아이디가 있는지 부터 검사)
-    @GetMapping("/is-member")
-    public MemberEmailResponse isMember(@RequestParam("email") @NotEmpty String email){
-        boolean isMember = memberService.isMember(email);
-        return new MemberEmailResponse(email,isMember);
-    }
     // 비밀번호 수정
     // 기존비밀번호 확인이 체크가 되어있거나
     // 혹은 현재 로그인한 사용자가 바꾸길 원하는 이메일과 같은 경우
     @PostMapping("/change-password")
     public void changePwd(@RequestBody @Valid ChangePwdRequest request){
-        memberService.changePwd(request.getEmail(),request.getPassword());
+        memberService.changePwd(request.getEmail(), request.getPassword());
     }
-    // 이메일 코드 발송
-    @PostMapping("/code-send")
-    public String sendEmailCode(@RequestBody @Valid EmailRequest emailRequest){
+    // 회원가입 시 코드 발송
+    @PostMapping("/register/code")
+    public String sendEmailCodeForRegistration(@RequestBody @Valid EmailRequest emailRequest){
         return memberService.sendEmailCode(emailRequest.getEmail());
+    }
+
+    // 비밀번호 재설정 시 코드 발송
+    @PostMapping("/change-password/code")
+    public String sendEmailCodeForPasswordReset(@RequestBody @Valid EmailRequest emailRequest) {
+        return memberService.setEmailCodeForPasswordReset(emailRequest.getEmail());
     }
     // 이메일 코드 검증
     @PostMapping("/code-valid")

--- a/src/main/java/cherish/backend/member/email/service/AwsEmailService.java
+++ b/src/main/java/cherish/backend/member/email/service/AwsEmailService.java
@@ -5,13 +5,13 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.model.SendEmailResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.MailSendException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Profile("aws")
-@Service
 @RequiredArgsConstructor
 public class AwsEmailService implements EmailService {
     private final AmazonSimpleEmailService amazonSimpleEmailService;

--- a/src/main/java/cherish/backend/member/email/service/GoogleEmailService.java
+++ b/src/main/java/cherish/backend/member/email/service/GoogleEmailService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @RequiredArgsConstructor
-@Profile("google")
 @Service
 public class GoogleEmailService implements EmailService {
 

--- a/src/main/java/cherish/backend/member/email/service/GoogleEmailService.java
+++ b/src/main/java/cherish/backend/member/email/service/GoogleEmailService.java
@@ -29,5 +29,6 @@ public class GoogleEmailService implements EmailService {
         message.setSubject(title);
         message.setText(content);
         mailSender.send(message);
+        log.info("A mail has been sent to {}\ncontent : {}", to, content);
     }
 }

--- a/src/main/java/cherish/backend/test/TestRestController.java
+++ b/src/main/java/cherish/backend/test/TestRestController.java
@@ -28,25 +28,14 @@ public class TestRestController {
         return "Process Success !!";
     }
 
+    @PostMapping("/redis")
+    public void testRedisPost() {
+        redisService.setEmailVerified("test", true, 500);
+    }
+
     @GetMapping("/redis")
-    public String testRedis() {
-        String uid = UUID.randomUUID().toString().substring(0, 7);
-        redisService.setRedisKeyValue("test",uid,10);
-        return uid;
-    }
-
-    @PostMapping("/redis/info")
-    public void testInfo() {
-        EmailVerificationInfoDto dto = EmailVerificationInfoDto.builder()
-            .code("111111")
-            .verified(false)
-            .build();
-        redisService.setRedisKeyValue("test", dto, 30);
-    }
-
-    @GetMapping("/redis/info")
-    public EmailVerificationInfoDto getTestInfo() {
-        return redisService.getValue("test", EmailVerificationInfoDto.class);
+    public boolean testRedis() {
+        return redisService.isEmailVerified("test");
     }
 
     @GetMapping

--- a/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
+++ b/src/test/java/cherish/backend/member/controller/MemberControllerTest.java
@@ -72,13 +72,13 @@ class MemberControllerTest {
     void 로그인_테스트() throws Exception {
         //given
         Member member = Member.builder().id(1L).name("test").email("test@naver.com").password("12345").build();
-        given(memberService.login(member.getEmail(), member.getPassword(),false )).willReturn(
+        given(memberService.login(member.getEmail(), member.getPassword())).willReturn(
                 TokenInfo.builder()
                 .grantType("Bearer").refreshToken("abc").accessToken("cde").build()
         );
         //when
         //then
-        String content = objectMapper.writeValueAsString(new MemberLoginRequestDto("test@naver.com", "12345", false));
+        String content = objectMapper.writeValueAsString(new MemberLoginRequestDto("test@naver.com", "12345"));
         mvc.perform(post("/public/member/login")
                         .content(content)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
이메일 인증 로직 변경을 위해 Redis 관련 로직도 아래처럼 변경했습니다.

1. Redis는 String 키, String 값 쌍으로 구성
2. key를 저장할때 유저 이메일 앞에 특정 로직의 prefix를 붙여서 사용
2-1. refresh token
2-2. email 인증코드
2-3. email 인증 여부
2-4. email 인증 횟수

3. 비밀번호 변경시에도 이메일 인증과 인증여부, 인증횟수 검증하는 로직 추가