### PR TITLE
fix: Cors config 허용되는 origin을 application.yml로 관리하게 변경 및 프론트엔드 로컬 오리진 추가

### DIFF
--- a/src/main/java/cherish/backend/auth/security/SecurityConfig.java
+++ b/src/main/java/cherish/backend/auth/security/SecurityConfig.java
@@ -3,8 +3,9 @@ package cherish.backend.auth.security;
 import cherish.backend.auth.jwt.JwtAuthenticationFilter;
 import cherish.backend.auth.jwt.JwtExceptionFilter;
 import cherish.backend.auth.jwt.JwtTokenProvider;
-import cherish.backend.common.constant.CommonConstants;
+import cherish.backend.common.config.cors.CorsProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,12 +22,14 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+@EnableConfigurationProperties(CorsProperties.class)
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final CorsProperties corsProperties;
     // 현재 화이트 리스트 모두 열어 놓음
     private static final String[] PUBLIC_WHITELIST = {
             "/public/**", "/test/**"
@@ -69,8 +72,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.addAllowedOrigin(CommonConstants.LOCALHOST);
-        config.addAllowedOrigin(CommonConstants.CLIENT_ORIGIN); // 프론트 IPv4 주소
+        corsProperties.getAllowedOrigins().forEach(config::addAllowedOrigin);
         config.addAllowedMethod(""); // 모든 메소드 허용.
         config.addAllowedHeader("");
         config.setAllowCredentials(true);

--- a/src/main/java/cherish/backend/common/config/cors/CorsProperties.java
+++ b/src/main/java/cherish/backend/common/config/cors/CorsProperties.java
@@ -1,0 +1,14 @@
+package cherish.backend.common.config.cors;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Set;
+
+@Data
+@ConfigurationProperties(prefix = CorsProperties.CORS_PREFIX)
+public class CorsProperties {
+    public static final String CORS_PREFIX = "cors";
+
+    private Set<String> allowedOrigins;
+}

--- a/src/main/java/cherish/backend/common/constant/CommonConstants.java
+++ b/src/main/java/cherish/backend/common/constant/CommonConstants.java
@@ -4,8 +4,5 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class CommonConstants {
-    public static final String LOCALHOST = "http://localhost:8080";
-    public static final String CLIENT_ORIGIN = "https://rococo-paprenjak-9b8d81.netlify.app";
-
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh-token";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,11 @@ jwt:
   secret: akwEyVBsYt9djeG77Tejkeo83yzblYcfPQye08f7MGVdjdo19A
   access-token-expire-time: 30m
   refresh-token-expire-time: 14d
+cors:
+  allowed-origins:
+    - http://127.0.0.1:5173
+    - https://127.0.0.1:5173
+    - https://rococo-paprenjak-9b8d81.netlify.app
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://cherishu-db.czzht1ogb1na.ap-northeast-2.rds.amazonaws.com:5432/cherishu?stringtype=unspecified
     username: postgres
+    password: ${PASSWORD}
   lifecycle:
     timeout-per-shutdown-phase: 35s
   jpa:


### PR DESCRIPTION
- CORS에 허용되는 origin을 application yml을 통해 관리하도록 변경합니다.