### PR TITLE
fix: allowed origins 도메인 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,9 +66,7 @@ cors:
     - DELETE
     - OPTIONS
   allowed-origins:
-    - http://127.0.0.1:5173
-    - https://127.0.0.1:5173
-    - https://rococo-paprenjak-9b8d81.netlify.app
+    - https://cherishu.firebaseapp.com
 ---
 spring:
   config:


### PR DESCRIPTION
allowed origins에 새로운 프론트엔드 도메인으로 변경했습니다

- 추가로 ec2 내의 nginx 설정에서도 추가할 예정입니다.
    - 현재 preflight 요청은 nginx 단계에서 OK로 보내는중