### PR TITLE
페이징 결과를 담는 공통 response dto 추가

### DIFF
--- a/src/main/java/cherish/backend/common/dto/PageResponse.java
+++ b/src/main/java/cherish/backend/common/dto/PageResponse.java
@@ -15,7 +15,7 @@ public class PageResponse<T> {
     public PageResponse(Page<T> page) {
         this.data = page.getContent();
         this.pageInfo = PageInfo.builder()
-            .pageNumber(page.getNumber())
+            .pageNumber(page.getNumber() + 1)
             .pageSize(page.getSize())
             .totalPages(page.getTotalPages())
             .totalElements(page.getTotalElements())

--- a/src/main/java/cherish/backend/common/dto/PageResponse.java
+++ b/src/main/java/cherish/backend/common/dto/PageResponse.java
@@ -1,0 +1,37 @@
+package cherish.backend.common.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+public class PageResponse<T> {
+
+    private List<T> data;
+    private PageInfo pageInfo;
+
+    public PageResponse(Page<T> page) {
+        this.data = page.getContent();
+        this.pageInfo = PageInfo.builder()
+            .pageNumber(page.getNumber())
+            .pageSize(page.getSize())
+            .totalPages(page.getTotalPages())
+            .totalElements(page.getTotalElements())
+            .first(page.isFirst())
+            .last(page.isLast())
+            .build();
+    }
+
+    @Builder
+    @Data
+    static class PageInfo {
+        private int pageNumber;
+        private int pageSize;
+        private int totalPages;
+        private long totalElements;
+        private boolean first;
+        private boolean last;
+    }
+}


### PR DESCRIPTION
```json
{
    "data": [
        {
            "title": "테스트",
            "content": "테스트",
            "createdDate": "2023년 05월 11일"
        }
    ],
    "pageInfo": {
        "pageNumber": 1,
        "pageSize": 1,
        "totalPages": 2,
        "totalElements": 2,
        "first": true,
        "last": false
    }
}
```
이런식의 구조로 만들었습니다

현재는 그냥 생성자로 

```java
public PageResponse(Page<T> page);
```
만 있는데 나중에 static 메소드도 고려해볼만 합니다.

사용법은 jpa repository로부터 얻은 `Page<>` 객체를 생성자의 파라미터로 넘겨서 만든
`PageResponse` 객체를 컨트롤러가 리턴하면 됩니다