### PR TITLE
Refactor/139 send email async

### DIFF
--- a/src/main/java/cherish/backend/common/config/AsyncConfig.java
+++ b/src/main/java/cherish/backend/common/config/AsyncConfig.java
@@ -1,0 +1,20 @@
+package cherish.backend.common.config;
+
+import cherish.backend.common.constant.CommonConstants;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = CommonConstants.MAIL_TASK_EXECUTOR_NAME, destroyMethod = "shutdown")
+    public ThreadPoolTaskExecutor mailTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(10);
+        return executor;
+    }
+}

--- a/src/main/java/cherish/backend/common/constant/CommonConstants.java
+++ b/src/main/java/cherish/backend/common/constant/CommonConstants.java
@@ -5,4 +5,5 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class CommonConstants {
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh-token";
+    public static final String MAIL_TASK_EXECUTOR_NAME = "mailTaskExecutor";
 }

--- a/src/main/java/cherish/backend/member/email/service/EmailService.java
+++ b/src/main/java/cherish/backend/member/email/service/EmailService.java
@@ -1,5 +1,9 @@
 package cherish.backend.member.email.service;
 
+import cherish.backend.common.constant.CommonConstants;
+import org.springframework.scheduling.annotation.Async;
+
 public interface EmailService {
+    @Async(CommonConstants.MAIL_TASK_EXECUTOR_NAME)
     void sendMessage(String to, String code);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ server:
       cookie:
         same-site: none
         secure: true
-        domain: https://cherishu.web.app
+        domain: cherishu.web.app
 
 spring:
   datasource:


### PR DESCRIPTION
smtp를 통한 이메일 전송이 오래걸려서 비동기 전송방식으로 변경했습니다.

- 참고한 사이트
[https://goodgid.github.io/SpringBoot-Why-doesn't-it-work-with-Async/](https://goodgid.github.io/SpringBoot-Why-doesn't-it-work-with-Async/)

단순히 `@EnableAsync`만 추가하고 `@Async`만 추가한다고 해서 동작하는게 아니더라고요

저희가 webflux 기반이었으면 다른 방법을 시도했겠지만 mvc 기반이라 `@Async`로 처리했습니다