### PR TITLE
[refactor] itemLike 중복으로 여러번 DB에 저장되는 이슈

### DIFF
--- a/src/main/java/cherish/backend/item/constant/ItemConstant.java
+++ b/src/main/java/cherish/backend/item/constant/ItemConstant.java
@@ -5,4 +5,5 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class ItemConstant {
     public static final String ITEM_NOT_FOUND = "해당 상품이 없습니다.";
+    public static final String ITEM_LIKE_EXISTS = "해당 상품의 좋아요가 이미 존재합니다.";
 }

--- a/src/main/java/cherish/backend/item/repository/ItemLikeRepository.java
+++ b/src/main/java/cherish/backend/item/repository/ItemLikeRepository.java
@@ -1,7 +1,11 @@
 package cherish.backend.item.repository;
 
 import cherish.backend.item.model.ItemLike;
+import cherish.backend.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ItemLikeRepository extends JpaRepository<ItemLike,Long>, ItemLikeRepositoryCustom{
+    Optional<ItemLike> findItemLikeByItemIdAndMember(Long itemId, Member member);
 }

--- a/src/main/java/cherish/backend/item/repository/RecommendItemRepository.java
+++ b/src/main/java/cherish/backend/item/repository/RecommendItemRepository.java
@@ -3,9 +3,12 @@ package cherish.backend.item.repository;
 import cherish.backend.item.dto.QRecommendItemQueryDto;
 import cherish.backend.item.dto.RecommendItemQueryDto;
 import cherish.backend.member.model.Member;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -23,16 +26,33 @@ public class RecommendItemRepository {
     private final JPAQueryFactory queryFactory;
 
     public List<RecommendItemQueryDto> getRecommendItemList(Member member) {
-        BooleanExpression like = member != null ? new CaseBuilder().when(itemLike.member.eq(member)).then(true).otherwise(false) : Expressions.asBoolean(false);
+        BooleanExpression like = Expressions.asBoolean(false);
 
-        return queryFactory
+        JPAQuery<RecommendItemQueryDto> query = queryFactory
                 .select(new QRecommendItemQueryDto(
                         recommend.id, item.id, item.name, item.brand, item.price, item.imgUrl, like, recommend.title, recommend.subTitle, recommend.linkParam)
                 )
                 .from(recommendItem)
                 .leftJoin(recommendItem.item, item)
-                .leftJoin(recommendItem.recommend, recommend)
-                .leftJoin(recommendItem.item.itemLikes, itemLike)
-                .fetch();
+                .leftJoin(recommendItem.recommend, recommend);
+
+        if (member != null) {
+            query = query.leftJoin(recommendItem.item.itemLikes, itemLike)
+                    .on(itemLike.member.eq(member).and(itemLike.item.eq(item)))
+                    .where(itemLike.id.in(
+                            JPAExpressions.select(itemLike.id)
+                                    .from(itemLike)
+                                    .where(itemLike.member.eq(member), itemLike.item.eq(item))
+                                    .groupBy(itemLike.item.id)
+                                    .having(itemLike.item.id.count().gt(1))
+                    ));
+            like = new CaseBuilder()
+                    .when(itemLike.id.isNotNull())
+                    .then((Predicate) Expressions.asBoolean(true))
+                    .otherwise(Expressions.asBoolean(false));
+        }
+
+        return query.fetch();
     }
+
 }

--- a/src/main/java/cherish/backend/item/service/ItemLikeService.java
+++ b/src/main/java/cherish/backend/item/service/ItemLikeService.java
@@ -28,9 +28,14 @@ public class ItemLikeService {
     public Long likeItem(Member member, Long itemId){
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new IllegalStateException(ItemConstant.ITEM_NOT_FOUND));
         ItemLike itemLike = ItemLike.createItemLike(member, item);
-        itemLikeRepository.save(itemLike);
+        if (itemLikeRepository.findItemLikeByItemIdAndMember(itemId, member).isEmpty()) {
+            itemLikeRepository.save(itemLike);
+        } else {
+            throw new IllegalStateException(ItemConstant.ITEM_LIKE_EXISTS);
+        }
         return itemLike.getId();
     }
+
     // 삭제
     @Transactional
     public void deleteLikeItem(Long itemId, String email){

--- a/src/main/java/cherish/backend/item/service/RecommendItemService.java
+++ b/src/main/java/cherish/backend/item/service/RecommendItemService.java
@@ -35,6 +35,7 @@ public class RecommendItemService {
                 .map(entry -> {
                     List<RecommendItemResponseDto.RecommendItemDto> recommendItemDtos = entry.getValue().stream()
                             .map(RecommendItemResponseDto.RecommendItemDto::item)
+                            .distinct()
                             .toList();
 
                     RecommendItemQueryDto itemQueryDto = entry.getValue().get(0);

--- a/src/test/java/cherish/backend/item/controller/ItemSearchControllerTest.java
+++ b/src/test/java/cherish/backend/item/controller/ItemSearchControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class ItemSearchControllerTest {
         List<ItemSearchResponseDto> expected = Arrays.asList(
                 new ItemSearchResponseDto(1008L, "캐롯 카로틴 카밍 워터 패드 (250g, 60매)", "스킨푸드",
                         "스킨푸드의 베스트셀러, 당근패드에요. 자연의 당근씨 오일에서 얻은 베타카로틴 성분이 함유되어 있어 무너진 피부 컨디션을 진정시켜줘요.",
-                        26000, "https://firebasestorage.googleapis.com/v0/b/quickstart-1606792103333.appspot.com/o/img%2Fitem%2F01008.png?alt=media", false));
+                        26000, "https://firebasestorage.googleapis.com/v0/b/quickstart-1606792103333.appspot.com/o/img%2Fitem%2F01008.png?alt=media", false, 5, LocalDate.now()));
         Page<ItemSearchResponseDto> page = new PageImpl<>(expected, pageable, 20);
 
         given(itemService.searchItem(condition, member, pageable)).willReturn(page);


### PR DESCRIPTION
지금 보면 main page, 검색창 등등 각각의 페이지에서 저장 버튼을 누르면 해당 아이템에 중복으로 좋아요가 쌓이고, 
like list를 조회해보면 중복이 제거되어서 조회가 되네요

main page에서 상품이 여러개로 늘어나고 삭제해도 다시 list를 불러오면 유지되어 있고 그러한 문제들이 
하나의 item에 itemLike가 하나가 아닌 여러개가 들어가있어서 sql문이 하나의 id를 찾지 못해서 
그냥 중복으로 list를 뿌려주고 itemLike도 그냥 false로 유지하는 것 같습니다 ㅠ

![chrome_screenshot](https://github.com/Cherish-Gift/back-spring/assets/107406265/44deba09-c1f3-4279-bb7c-10bc888baa4e)

해당 이슈 해결하면 pr로 전환하겠습니다 

